### PR TITLE
Use relative_path in settings

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -19,7 +19,7 @@ let env = "@{env}", dev = (env === "development");
 
 /*===================================================== Exports  =====================================================*/
 
-exports.urlBase = nconf.get("url") + "/plugins/@{name}/static";
+exports.urlBase = nconf.get("relative_path") + "/plugins/@{name}/static";
 exports.name = "@{name}";
 exports.id = "@{id}";
 exports.Id = "@{Id}";


### PR DESCRIPTION
Prevents warnings about mixed content when reverse-proxying HTTPS. Also more consistent with how NodeBB’s base seems to operate.
